### PR TITLE
Adds OHC and TCHP support.

### DIFF
--- a/Docker/ubuntu20.04.ufs_tcdiags.dockerfile
+++ b/Docker/ubuntu20.04.ufs_tcdiags.dockerfile
@@ -18,6 +18,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV UFS_TCDIAGS_GIT_URL="https://www.github.com/HenryWinterbottom-NOAA/ufs_tcdiags.git"
 ENV UFS_TCDIAGS_GIT_BRANCH="develop"
 ENV TCDIAGS_ROOT="/home/ufs_tcdiags"
+ENV DIAGS_ROOT="/opt/ufs_diags"
 
 ENV TZ=Etc/UTC
 
@@ -29,5 +30,5 @@ RUN $(command -v apt-get) update -y && \
 RUN $(command -v git) clone --recursive "${UFS_TCDIAGS_GIT_URL}" --branch "${UFS_TCDIAGS_GIT_BRANCH}" "${TCDIAGS_ROOT}" && \
     $(command -v pip) install -r "${TCDIAGS_ROOT}/requirements.txt"
 
-ENV PYTHONPATH=${TCDIAGS_ROOT}/sorc:${TCDIAGS_ROOT}/jupyter/ush:/opt/ufs_diags/:${PYTHONPATH}
+ENV PYTHONPATH="${TCDIAGS_ROOT}/sorc:${TCDIAGS_ROOT}/jupyter/ush:${DIAGS_ROOT}/sorc:${PYTHONPATH}"
 EXPOSE 8888

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,6 +55,7 @@ executed as follows.
    :maxdepth: 1
 
    tcinfo.rst
+   ohc.rst
    tc.rst
    tcpi.rst
    metrics.rst

--- a/docs/source/lv1972_ohc.rst
+++ b/docs/source/lv1972_ohc.rst
@@ -4,7 +4,7 @@ Leipper and Volgenau (1972)
 This application diagnoses the Ocean Heat Content (OHC) relative to a
 specified isotherm depth relevant to tropical cyclone (TC) analysis
 and forecasting (e.g., Tropical Cyclone Heat Potential; TCHP). The
-application is based on that described in `Leipper and Volgenau, (1972) <https://doi.org/10.1175/1520-0485(1972)002<0218:HHPOTG>2.0.CO;2>`_.
+application is based on that described in `Leipper and Volgenau, (1972) <https://doi.org/10.1175/1520-0485(1972)002\<0218:HHPOTG\>2.0.CO;2>`_.
 
 ^^^^^^^^^^^^^
 Configuration

--- a/docs/source/lv1972_ohc.rst
+++ b/docs/source/lv1972_ohc.rst
@@ -1,0 +1,300 @@
+Leipper and Volgenau (1972)
+===========================
+
+This application diagnoses the Ocean Heat Content (OHC) relative to a
+specified isotherm depth relevant to tropical cyclone (TC) analysis
+and forecasting (e.g., Tropical Cyclone Heat Potential; TCHP). The
+application is based on that described in `Leipper and Volgenau, (1972) <https://doi.org/10.1175/1520-0485(1972)002<0218:HHPOTG>2.0.CO;2>`_.
+
+^^^^^^^^^^^^^
+Configuration
+^^^^^^^^^^^^^
+
+The following table provides and describes the configurable variables
+for the application. Note that if a **Default Value** is missing, the
+respective variable is mandatory.
+
+.. list-table::
+   :widths: auto
+   :header-rows: 1
+
+   * - **Variable**
+     - **Description**
+     - **Default**
+   * - ``deltaz``
+     - The depth interval for the vertical integration of the OHC in
+       order to compute the TCHP relative to the specified isotherm;
+       units must be identical to that of the ocean depth coordinate.
+     - 5.0 meters
+   * - ``fill_value``
+     - The missing value to be used when interpolating the temperature
+       variable to determine the depth of the specified isotherm; this
+       value is assigned if the depth of the isotherm is not within
+       the oceanic depth array values.
+     - ``numpy.nan``
+   * - ``interp_type``
+     - The interpolation type to determine the depth of the specified
+       isotherm.
+     - ``linear``
+   * - ``isotherm``
+     - The isothermal level relative to which to compute the TCHP.
+     - :math:`26^{o}\text{C}`
+   * - ``output_file``
+     - The netCDF-formatted file path to contain the specified output
+       variables.
+     - ``./tcdiags.lv1972_ohc.nc``
+   * - ``write_output``
+     - Boolean valued variable specifying whether to write the
+       netCDF-formatted output file defined by ``output_file``
+       (above).
+     - ``False``
+
+In addition to the above, the specified variables to be written to the
+output file (``output_file``) can be defined by the ``output_vars``
+key. The available output variables are provided in the following
+table.
+
+.. list-table::
+   :widths: auto
+   :header-rows: 1
+
+   * - **Variable Name**
+     - **Description**
+   * - ``isotherm``
+     - The relevant isotherm to compute the TCHP.
+   * - ``ohc``
+     - The OHC from which to compute the TCHP.
+   * - ``tchp``
+     - The TCHP.
+   * - ``lats``
+     - The latitude grid from which the respective gridded variables are derived.
+   * - ``lons``
+     - The longitude grid from which the respective gridded variables are derived.
+   * - ``depths``
+     - The oceanic depths from which the respective gridded variables are computed.
+   * - ``ctemp``
+     - The `conservative temperature <https://www.teos-10.org/pubs/gsw/html/gsw_CT_from_pt.html>`_.
+   * - ``asaln``
+     - The `absolute salinity <https://www.teos-10.org/pubs/gsw/html/gsw_SA_from_SP.html>`_.
+
+An example YAML-formatted configuration file is as follows.
+
+.. code-block:: yaml
+
+   app_module: tcdiags.lv1972_ohc
+   app_class: LV1972
+   schema: !ENV ${TCDIAGS_ROOT}/parm/schema/tcdiags.lv1972_ohc.yaml
+   write_output: true
+   output_file: ./tcdiags.lv1972_ohc.nc
+   output_vars:
+     tchp:
+       coords: &coords2d
+         - lat
+         - lon
+       attributes:
+         description: Tropical cyclone heat potential.
+     lats:
+       coords: *coords2d
+       attributes:
+         description: Latitudes.
+     lons:
+       coords: *coords2d
+       attributes:
+         description: Longitudes.
+     isotherm:
+       coords: *coords2d
+       attributes:
+         description: Isotherm depth.
+     asaln:
+       coords: &coords3d
+         - level   
+         - lat
+         - lon
+       attributes:
+         description: Absolute salinity.
+     ctemp:
+       coords: *coords3d
+       attributes:
+         description: Conservative temperature.
+     ohc:
+       coords: *coords3d
+       attributes:
+         description: Ocean heat content.
+     depths:
+       coords: *coords3d
+       attributes:
+         description: Ocean depth.
+
+
+Note that the application assumes that the environment variable
+``TCDIAGS_ROOT`` has been defined and points to the top-level
+directory of the ``ufs_tcdiags`` repository clone. Further, the
+``output_varlist`` points to a YAML-formatted file containing the
+variables to be written to ``output_file`` if ``write_output`` is
+``True``. A snippet containing some of the contents written to the
+netCDF-formatted file path follows.
+
+.. code-block:: bash
+
+   user@host:$ ncdump -h ./tcdiags.vl1991_strflw.nc
+
+   dimensions:
+	   plevs = 10 ;
+	   lat = 192 ;
+	   lon = 384 ;
+   variables:
+	   int64 plevs(plevs) ;
+	   double lat(lat) ;
+		   lat:_FillValue = NaN ;
+	   double lon(lon) ;
+		   lon:_FillValue = NaN ;
+	   double chi(plevs, lat, lon) ;
+		   chi:_FillValue = 9.96920996838687e+36 ;
+		   chi:missing_value = 9.96920996838687e+36 ;
+		   chi:description = "\"The velocity potential field.\"\n" ;
+		   chi:name = "velocity potential" ;
+		   chi:units = "meters^2/second" ;
+	   double divg(plevs, lat, lon) ;
+	     	   divg:_FillValue = 9.96920996838687e+36 ;
+		   divg:missing_value = 9.96920996838687e+36 ;
+		   divg:description = "\"The total divergence field.\"\n" ;
+		   divg:name = "divergence" ;
+		   divg:units = "1/second" ;
+
+^^^^^^^^^^^^^^^^^^^^^^^
+Running the Application
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The TC steering flow application can be executed using a variety of
+methods. Each is described below.
+
+========
+Terminal
+========
+
+The TC steering flow application may be executed within an supporting
+environment as follows.
+
+.. code-block:: bash
+
+   user@host:$ export PYTHONPATH="/path/to/ufs_tcdiags/ush":"${PYTHONPATH}"
+   user@host:$ cd /path/to/ufs_tcdiags/scripts
+   user@host:$ ./compute_tcdiags.py --help
+
+   Usage: compute_tcdiags.py [-h] [-tcmsi] [-tcpi] [-tcstrflw] yaml
+
+   Tropical cyclone diagnostics computation(s) application interface.
+
+   Positional Arguments:
+     yaml        YAML-formatted tropical cyclone diagnostics configuration file.
+
+   Optional Arguments:
+     -h, --help  show this help message and exit
+     -tcmsi      YAML-formatted file containing the TC multi-scale intensity application configuration.
+     -tcpi       YAML-formatted file containing the TC potential intensity application configuration.
+     -tcstrflw   YAML-formatted file containing the TC steering application configuration.
+
+   user@host:$ ./compute_tcdiags.py /path/to/ufs_tcdiags/parm/tcdiags.demo.yaml -tcstrflw
+
+================
+Jupyter Notebook
+================
+   
+The TC steering flow application can also be executed from within a
+Jupyter notebook as follows.
+
+.. code-block:: bash
+
+   user@host:$ export PYTHONPATH="/path/to/ufs_tcdiags/jupyter":"/path/to/ufs_tcdiags/ush":"${PYTHONPATH}"
+   user@host:$ cd /path/to/ufs_tcdiags/jupyter/notebooks
+   user@host:$ /path/to/jupyter notebook tcdiags.vl1991_strflw.ipynb
+
+This action behaves as the terminal instance for the application
+(above) but is executed from within the respective Jupyter notebook.
+
+================
+Docker Container
+================
+
+The TC steering flow application may be executed within an appropriate
+Docker container as follows.
+
+.. code-block:: bash
+
+   user@host:$ /path/to/docker run -v /path/to/ufs_tcdiags:/home/ufs_tcdiags -it ghcr.io/henrywinterbottom-noaa/ubuntu20.04.ufs_tcdiags:latest
+   user@host:$ export PYTHONPATH="/home/ufs_tcdiags/ush":"${PYTHONPATH}"
+   user@host:$ cd /home/ufs_tcdiags/scripts
+   user@host:$ ./compute_tcdiags.py --help
+
+   Usage: compute_tcdiags.py [-h] [-tcmsi] [-tcpi] [-tcstrflw] yaml
+
+   Tropical cyclone diagnostics computation(s) application interface.
+
+   Positional Arguments:
+     yaml        YAML-formatted tropical cyclone diagnostics configuration file.
+
+   Optional Arguments:
+     -h, --help  show this help message and exit
+     -tcmsi      YAML-formatted file containing the TC multi-scale intensity application configuration.
+     -tcpi       YAML-formatted file containing the TC potential intensity application configuration.
+     -tcstrflw   YAML-formatted file containing the TC steering application configuration.
+
+   user@host:$ ./compute_tcdiags.py /home/ufs_tcdiags/parm/tcdiags.demo.yaml -tcstrflw
+
+==========================================
+Jupyter Notebook Within a Docker Container
+==========================================
+
+Similar to the Jupyter notebook and Docker container examples above,
+the Jupyter notebook can also be launched from within the Docker
+container. This can be accomplished as follows.
+
+.. code-block:: bash
+
+   user@host:$ /path/to/docker run -v /path/to/ufs_tcdiags:/home/ufs_tcdiags -p 8888:8888 -it ghcr.io/henrywinterbottom-noaa/ubuntu20.04.ufs_tcdiags:latest
+   user@host:$ export PYTHONPATH="/home/ufs_tcdiags/ush":"/home/ufs_tcdiags/jupyter":"${PYTHONPATH}"
+   user@host:$ cd /path/to/ufs_tcdiags/jupyter/notebooks
+   user@host:$ /path/to/jupyter notebook --ip=0.0.0.0 --port=8888 --no-browser --allow-root tcdiags.vl1991_strflw.ipynb
+
+The above action will provide the user a local HTML path and an
+associated token as follows.
+
+.. code-block:: bash
+
+    To access the server, open this file in a browser:
+        file:///root/.local/share/jupyter/runtime/jpserver-21362-open.html
+    Or copy and paste one of these URLs:
+	http://5186640b39b0:8889/tree?token=abcdefghijklmnopqrstuvwxwy0123456789ABCDEFGHIJKL
+        http://127.0.0.1:8889/tree?token=abcdefghijklmnopqrstuvwxwy0123456789ABCDEFGHIJKL
+
+Copy the paste the token attribute that begins with
+``http://127.0.0.1:8889`` into a web browser address bar and execute
+the respective Jupyter notebook as described above.
+
+^^^^^^^^^^^^^^^
+Example Results
+^^^^^^^^^^^^^^^
+
+The following example is computed from a nominally 1.0-degree `ERA5
+<https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5>`_
+analysis valid 0000 UTC 01 October 2016.
+
+.. list-table::
+   :widths: auto
+   :header-rows: 0   
+
+   * - .. figure:: _static/tcstrflw.shallow.png
+          :name: tcstrflw.shallow
+	  :align: center
+   *  - .. figure:: _static/tcstrflw.medium.png
+          :name: tcstrflw.medium
+	  :align: center
+   *  - .. figure:: _static/tcstrflw.deep.png
+          :name: tcstrflw.deep
+	  :align: center
+
+The layer-mean winds with respect to the intensity ranges illustrated
+by Figure 2 of `Velden and Leslie, (1991) <https://journals.ametsoc.org/view/journals/wefo/6/2/1520-0434_1991_006_0244_tbrbtc_2_0_co_2.xml>`_
+are shown above for the 850- to 500-hPa (top), 850- to 400-hPa
+(center), and 850- to 300-hPa (bottom). The TC locations, valid for
+0000 UTC 01 October 2016, are denoted by the respective red symbols.

--- a/docs/source/ohc.rst
+++ b/docs/source/ohc.rst
@@ -1,0 +1,10 @@
+Ocean Heat Content
+==================
+
+The following are the available ocean heat content metrics.
+
+.. toctree::
+   :maxdepth: 1
+
+   lv1972_ohc.rst
+	      

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -5,6 +5,8 @@ References
 
 `Gifford (2021) <https://doi.org/10.5194/gmd-14-2351-2021>`_
 
+`Leipper and Volgenau (1972) <https://doi.org/10.1175/1520-0485(1972)002<0218:HHPOTG>2.0.CO;2>`_
+
 `Velden and Leslie (1991) <https://journals.ametsoc.org/view/journals/wefo/6/2/1520-0434_1991_006_0244_tbrbtc_2_0_co_2.xml>`_
 
 `Vukicevic et al., (2014) <https://journals.ametsoc.org/view/journals/atsc/71/4/jas-d-13-0153.1.xml>`_

--- a/parm/inputs.mom6.yaml
+++ b/parm/inputs.mom6.yaml
@@ -1,0 +1,81 @@
+---
+io_module: tcdiags.io.read_analysis
+io_class: ReadAnalysis
+schema: !ENV ${TCDIAGS_ROOT}/parm/schema/tcdiags.read_analysis.mom6.yaml
+pottemp:
+  ncfile: &mom6_ncfile !ENV ${TCDIAGS_ROOT}/mom6.0p5.latlon.nc
+  ncvarname: temp
+  squeeze: true
+  squeeze_axis: 0
+  description: Potential temperatures.
+  unstructured: &grid false
+  name: pottemp
+  units: degC
+  coords: &coords3d
+   - depth
+   - lat
+   - lon
+salinity:
+  ncfile: *mom6_ncfile 
+  ncvarname: so
+  squeeze: true
+  squeeze_axis: 0
+  description: Practical salinities.
+  unstructured: *grid
+  name: salt
+  units: dimensionless
+  coords: *coords3d
+depth_profile:
+  ncfile: *mom6_ncfile
+  ncvarname: z_l
+  name: depth_profile
+  units: meter
+  grid_coord_idx: 0
+longitude:
+  ncfile: *mom6_ncfile
+  ncvarname: lon #geolon
+  scale_add: 0.0
+  description: Longitudes.
+  unstructured: *grid
+  name: lon
+  units: degree
+  unstructured: *grid
+  grid_coord_idx: 2
+  coords: &coords2d
+   - lat
+   - lon
+latitude:
+  ncfile: *mom6_ncfile
+  ncvarname: lat #geolat
+  description: Latitudes.
+  unstructured: *grid
+  name: lat
+  units: degree
+  grid_coord_idx: 1
+  coords: *coords2d
+ssh:
+  ncfile: *mom6_ncfile
+  ncvarname: SSH
+  name: ssh
+  description: Sea-surface heights.
+  unstructured: *grid
+  units: meter
+  coords: *coords2d
+depth:
+  derived: true
+  method: depth_from_profile
+  module: diags.derived.ocean.depths
+  description: Ocean depths.
+  unstructured: *grid
+  name: depth
+  units: meter
+  coords: *coords3d
+seawater_pressure:
+  derived: true
+  method: seawater_from_depth
+  module: diags.derived.ocean.pressures
+  description: Sea-water pressures.
+  name: seawater_pres
+  units: dbar
+  unstructured: *grid
+  coords: *coords3d

--- a/parm/ocean.demo.yaml
+++ b/parm/ocean.demo.yaml
@@ -1,0 +1,3 @@
+---
+inputs: !ENV ${TCDIAGS_ROOT}/parm/inputs.mom6.yaml
+tcohc: !ENV ${TCDIAGS_ROOT}/parm/ocean.lv1972_ohc.yaml

--- a/parm/ocean.lv1972_ohc.yaml
+++ b/parm/ocean.lv1972_ohc.yaml
@@ -1,24 +1,11 @@
 ---
+---
 app_module: tcdiags.lv1972_ohc
 app_class: LV1972
 schema: !ENV ${TCDIAGS_ROOT}/parm/schema/tcdiags.lv1972_ohc.yaml
-output_file: test.nc
+write_output: true
+output_file: ./tcdiags.lv1972_ohc.nc
 output_vars:
-  asaln:
-    coords: &coords3d
-      - level   
-      - lat
-      - lon
-    attributes:
-      description: Absolute salinity.
-  ctemp:
-    coords: *coords3d
-    attributes:
-      description: Conservative temperature.
-  ohc:
-    coords: *coords3d
-    attributes:
-      description: Ocean heat content.
   tchp:
     coords: &coords2d
       - lat
@@ -33,22 +20,23 @@ output_vars:
     coords: *coords2d
     attributes:
       description: Longitudes.
+  isotherm:
+    coords: *coords2d
+    attributes:
+      description: Isotherm depth.
+  ctemp:
+    coords: &coords3d
+      - level   
+      - lat
+      - lon
+    attributes:
+      description: Conservative temperature.
+  ohc:
+    coords: *coords3d
+    attributes:
+      description: Ocean heat content.
   depths:
     coords: *coords3d
     attributes:
       description: Ocean depth.
 
-
-# TODO: Units should be written to netCDF-output file regardless of
-# attributes specified above; if specified here, override the value
-# assigned to the object.
-
-
-#  - "asaln"
- # - "ohc"
- # - "tchp"
- # - "isotherm"
- # - "ctemp"
-#  - "depth"
-#  - "lats"
-#  - "lons"

--- a/parm/ocean.lv1972_ohc.yaml
+++ b/parm/ocean.lv1972_ohc.yaml
@@ -1,5 +1,4 @@
 ---
----
 app_module: tcdiags.lv1972_ohc
 app_class: LV1972
 schema: !ENV ${TCDIAGS_ROOT}/parm/schema/tcdiags.lv1972_ohc.yaml

--- a/parm/ocean.lv1972_ohc.yaml
+++ b/parm/ocean.lv1972_ohc.yaml
@@ -1,0 +1,54 @@
+---
+app_module: tcdiags.lv1972_ohc
+app_class: LV1972
+schema: !ENV ${TCDIAGS_ROOT}/parm/schema/tcdiags.lv1972_ohc.yaml
+output_file: test.nc
+output_vars:
+  asaln:
+    coords: &coords3d
+      - level   
+      - lat
+      - lon
+    attributes:
+      description: Absolute salinity.
+  ctemp:
+    coords: *coords3d
+    attributes:
+      description: Conservative temperature.
+  ohc:
+    coords: *coords3d
+    attributes:
+      description: Ocean heat content.
+  tchp:
+    coords: &coords2d
+      - lat
+      - lon
+    attributes:
+      description: Tropical cyclone heat potential.
+  lats:
+    coords: *coords2d
+    attributes:
+      description: Latitudes.
+  lons:
+    coords: *coords2d
+    attributes:
+      description: Longitudes.
+  depths:
+    coords: *coords3d
+    attributes:
+      description: Ocean depth.
+
+
+# TODO: Units should be written to netCDF-output file regardless of
+# attributes specified above; if specified here, override the value
+# assigned to the object.
+
+
+#  - "asaln"
+ # - "ohc"
+ # - "tchp"
+ # - "isotherm"
+ # - "ctemp"
+#  - "depth"
+#  - "lats"
+#  - "lons"

--- a/parm/ocean.lv1972_ohc.yaml
+++ b/parm/ocean.lv1972_ohc.yaml
@@ -23,11 +23,15 @@ output_vars:
     coords: *coords2d
     attributes:
       description: Isotherm depth.
-  ctemp:
+  asaln:
     coords: &coords3d
       - level   
       - lat
       - lon
+    attributes:
+      description: Absolute salinity.
+  ctemp:
+    coords: *coords3d
     attributes:
       description: Conservative temperature.
   ohc:

--- a/parm/schema/tcdiags.lv1972_ohc.yaml
+++ b/parm/schema/tcdiags.lv1972_ohc.yaml
@@ -1,7 +1,7 @@
 ---
 output_file:
   required: false
-  default: null
+  default: ./tcdiags.lv1972_ohc.nc
   type: str
 write_output:
   required: false

--- a/parm/schema/tcdiags.lv1972_ohc.yaml
+++ b/parm/schema/tcdiags.lv1972_ohc.yaml
@@ -1,0 +1,25 @@
+---
+output_file:
+  required: false
+  default: null
+  type: str
+write_output:
+  required: false
+  type: bool
+  default: false
+isotherm:
+  required: false
+  type: float
+  default: 26.0
+deltaz:
+  required: false
+  type: float
+  default: 5.0
+interp_type:
+  required: false
+  type: str
+  default: linear
+fill_value:
+  required: false
+  type: str
+  default: numpy.nan

--- a/parm/schema/tcdiags.read_analysis.mom6.yaml
+++ b/parm/schema/tcdiags.read_analysis.mom6.yaml
@@ -1,0 +1,64 @@
+---
+derived:
+  required: false
+  default: false
+  type: bool
+flip_lat:
+  required: false
+  default: false
+  type: bool
+flip_z:
+  required: false
+  default: false
+  type: bool
+method:
+  required: false
+  type: str
+  default: null
+module:
+  required: false
+  type: str
+  default: null
+ncfile:
+  required: false
+  type: str
+  default: null
+scale_mult:
+  required: false
+  type: float
+  default: 1.0
+scale_add:
+  required: false
+  type: float
+  default: 0.0
+squeeze:
+  required: false
+  type: bool
+  default: false
+squeeze_axis:
+  required: false
+  type: int
+  default: 0
+ncvarname:
+  required: false
+  type: str
+  default: null
+name:
+  required: true
+  type: str
+units:
+  required: true
+  type: str
+description:
+  required: false
+  default: null
+  type: str
+unstructured:
+  required: false
+  default: false
+  type: bool
+grid_coord_idx:
+  required: false
+  default: null
+  type: int
+

--- a/scripts/schema/compute_tcdiags.schema.yaml
+++ b/scripts/schema/compute_tcdiags.schema.yaml
@@ -3,7 +3,6 @@ yaml:
   help: |
     YAML-formatted tropical cyclone diagnostics configuration file.
   longname: yaml
-  shortname: y
   required: true
   type: str
 tcmsi:
@@ -17,6 +16,12 @@ tcpi:
     YAML-formatted file containing the TC potential intensity application
     configuration.
   longname: tcpi
+  action: store_true
+tcohc:
+  help: >
+    YAML-formatted file containing the TC relative ocean heat-content  application
+    configuration.
+  longname: tcohc 
   action: store_true
 tcstrflw:
   help: |

--- a/sorc/tcdiags/be2002_pi.py
+++ b/sorc/tcdiags/be2002_pi.py
@@ -15,8 +15,8 @@ Classes
 
     BE2002(tcdiags_obj)
 
-        This is the base-class object for all tropical cyclone(TC)
-        potential intensity(PI) computations following Bister and
+        This is the base-class object for all tropical cyclone (TC)
+        potential intensity (PI) computations following Bister and
         Emanuel [2002] and via the software provided by Gifford,
         D. M., [2020]; it is a sub-class of Metrics.
 
@@ -78,8 +78,8 @@ class BE2002(Diagnostics):
     Description
     -----------
 
-    This is the base-class object for all tropical cyclone(TC)
-    potential intensity(PI) computations following Bister and Emanuel
+    This is the base-class object for all tropical cyclone (TC)
+    potential intensity (PI) computations following Bister and Emanuel
     [2002] and via the software provided by Gifford, D. M., [2020]; it
     is a sub-class of Metrics.
 

--- a/sorc/tcdiags/diagnostics.py
+++ b/sorc/tcdiags/diagnostics.py
@@ -42,11 +42,13 @@ History
 
 # ----
 
+# pylint: disable=fixme
+# pylint: disable=no-value-for-parameter
+# pylint: disable=too-many-arguments
 # pylint: disable=unused-argument
 
 # ----
 
-from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Dict, Generic, List, Tuple
 
@@ -56,7 +58,7 @@ from utils import schema_interface
 from utils.decorator_interface import privatemethod
 from utils.logger_interface import Logger
 
-#from tcdiags.io.nc_write import NCWrite # TODO
+from tcdiags.io.nc_write import NCWrite  # TODO
 
 # ----
 
@@ -77,14 +79,14 @@ class Diagnostics:
     Parameters
     ----------
 
-    tcdiags_obj: SimpleNamespace
+    tcdiags_obj: ``SimpleNamespace``
 
         A Python SimpleNamespace object containing all configuration
         attributes for the respective application including inputs
         (i.e., `inputs` and `tcinfo`) as well as the remaining
         (supported) applications.
 
-    app: str
+    app: ``str``
 
         A Python string specifying the respective sub-class
         application; see `TCDiags` class attribute `app_list`.
@@ -92,12 +94,12 @@ class Diagnostics:
     Other Parameters
     ----------------
 
-    args: Tuple
+    args: ``Tuple``
 
         A Python tuple containing additional arguments passed to the
         constructor.
 
-    kwargs: Dict
+    kwargs: ``Dict``
 
         A Python dictionary containing additional key and value pairs
         to be passed to the constructor.
@@ -120,21 +122,22 @@ class Diagnostics:
         """
 
         # Define the base-class attributes.
-        self.logger = Logger(
-            caller_name=f"{__name__}.{self.__class__.__name__}")
+        self.logger = Logger(caller_name=f"{__name__}.{self.__class__.__name__}")
         self.tcdiags_obj = tcdiags_obj
         cls_schema_file = parser_interface.object_getattr(
-            object_in=self.tcdiags_obj, key=app, force=True).schema
+            object_in=self.tcdiags_obj, key=app, force=True
+        ).schema
         cls_opts = parser_interface.object_todict(
             object_in=parser_interface.object_getattr(
-                object_in=self.tcdiags_obj, key=app, force=True))
-        self.options_obj = self.schema(cls_schema_file=cls_schema_file,
-                                       cls_opts=cls_opts)
+                object_in=self.tcdiags_obj, key=app, force=True
+            )
+        )
+        self.options_obj = self.schema(
+            cls_schema_file=cls_schema_file, cls_opts=cls_opts
+        )
 
     @privatemethod
-    def schema(
-        self: Generic, cls_schema_file: str, cls_opts: Dict
-    ) -> SimpleNamespace:
+    def schema(self: Generic, cls_schema_file: str, cls_opts: Dict) -> SimpleNamespace:
         """
         Description
         -----------
@@ -142,14 +145,14 @@ class Diagnostics:
         This method evaluates the schema corresponding to the
         respective application.
 
-        cls_schema_file: str
+        cls_schema_file: ``str``
 
             A Python string specifying the file path for the
             YAML-formatted file containing the schema attributes for
             the respective application (base-class attribute
             `app_obj`).
 
-        cls_opts: Dict
+        cls_opts: ``Dict``
 
             A Python dictionary containing the configuration defined
             options for the respective application (base-class
@@ -158,7 +161,7 @@ class Diagnostics:
         Returns
         -------
 
-        options_obj: SimpleNamespace
+        options_obj: ``SimpleNamespace``
 
             A Python SimpleNamespace containing the respective
             application configuration.
@@ -168,8 +171,7 @@ class Diagnostics:
         # Evaluate the schema and define the configuration for the
         # respective application.
         schema_def_dict = YAML().read_yaml(yaml_file=cls_schema_file)
-        cls_schema = schema_interface.build_schema(
-            schema_def_dict=schema_def_dict)
+        cls_schema = schema_interface.build_schema(schema_def_dict=schema_def_dict)
         options_obj = parser_interface.dict_toobject(
             in_dict=schema_interface.validate_schema(
                 cls_schema=cls_schema, cls_opts=cls_opts, write_table=True
@@ -179,12 +181,12 @@ class Diagnostics:
         return options_obj
 
     def write_output(
-            self: Generic,
-            output_file: str,
-            var_obj: SimpleNamespace,
-            var_list: List,
-            coords_2d: Dict = None,
-            coords_3d: Dict = None,
+        self: Generic,
+        output_file: str,
+        var_obj: SimpleNamespace,
+        var_list: List,
+        coords_2d: Dict = None,
+        coords_3d: Dict = None,
     ) -> None:
         """
         Description
@@ -197,30 +199,30 @@ class Diagnostics:
         Parameters
         ----------
 
-        output_file: str
+        output_file: ``str``
 
             A Python string defining the path to the output
             netCDF-formatted file.
 
-        var_obj: SimpleNamespace
+        var_obj: ``SimpleNamespace``
 
             A Python SimpleNamespace object containing the quantities
             to be written to the output netCDF-formatted file.
 
-        var_list: List
+        var_list: ``List``
 
             A Python list of output variables.
 
         Keywords
         --------
 
-        coords_2d: Dict, optional
+        coords_2d: ``Dict``, optional
 
             A Python dictionary containing the 2-dimensional
             coordinate and dimension attributes; this is assumes CF
             compliance.
 
-        coords_3d: Dict, optional
+        coords_3d: ``Dict``, optional
 
             A Python dictionary containing the 3-dimensional
             coordinate and dimension attributes; this is assumes CF
@@ -236,6 +238,7 @@ class Diagnostics:
             var_obj=var_obj, var_list=var_list, coords_2d=coords_2d, coords_3d=coords_3d
         )
 
+
 # ----
 
 
@@ -250,14 +253,14 @@ class Metrics(Diagnostics):
     Parameters
     ----------
 
-    tcdiags_obj: SimpleNamespace
+    tcdiags_obj: ``SimpleNamespace``
 
         A Python SimpleNamespace object containing all configuration
         attributes for the respective application including inputs
         (i.e., `inputs` and `tcinfo`) as well as the remaining
         (supported) applications.
 
-    app_obj: SimpleNamespace
+    app_obj: ``SimpleNamespace``
 
         A Python SimpleNamespace object containing the attributes for
         the respective sub-class application.
@@ -265,12 +268,12 @@ class Metrics(Diagnostics):
     Other Parameters
     ----------------
 
-    args: Tuple
+    args: ``Tuple``
 
         A Python tuple containing additional arguments passed to the
         constructor.
 
-    kwargs: Dict
+    kwargs: ``Dict``
 
         A Python dictionary containing additional key and value pairs
         to be passed to the constructor.
@@ -293,6 +296,3 @@ class Metrics(Diagnostics):
 
         # Define the base-class attributes.
         super().__init__(tcdiags_obj=tcdiags_obj)
-
-
-# ----

--- a/sorc/tcdiags/diagnostics.py
+++ b/sorc/tcdiags/diagnostics.py
@@ -56,7 +56,7 @@ from utils import schema_interface
 from utils.decorator_interface import privatemethod
 from utils.logger_interface import Logger
 
-from tcdiags.io.nc_write import NCWrite
+#from tcdiags.io.nc_write import NCWrite # TODO
 
 # ----
 

--- a/sorc/tcdiags/io/ncwrite.py
+++ b/sorc/tcdiags/io/ncwrite.py
@@ -1,0 +1,342 @@
+"""
+Module
+------
+
+    ncwrite.py
+
+Description
+-----------
+
+    This module contains functions to build and write netCDF-formatted
+    file paths.
+
+Functions
+---------
+
+    __getcoords__(ncio_obj)
+
+        This function defines the Climate and Forecast (CF) Metadata
+        Convention compliant grid-coordinates.
+
+    __getvarobj__(ncio_obj)
+
+        This function builds a Python SimpleNamespace object
+        containing the output variable attributes.
+
+    __write__(xarrlist, ncoutput)
+
+        This function writes the netCDF-formatted file path.
+
+    __xarraylist__(varobj, coords_dict)
+
+        This method builds a Python list of DataArray objects to be
+        used to build and write the netCDF-formatted file path.
+
+    ncwrite(func)
+
+        This function is a wrapper function for build and writing
+        netCDF-formatted files.
+
+Requirements
+------------
+
+- ufs_pytils; https://github.com/HenryWinterbottom-NOAA/ufs_pyutils
+
+- xarray; https://github.com/pydata/xarray
+
+Author(s)
+---------
+
+    Henry R. Winterbottom; 13 March 2023
+
+History
+-------
+
+    2023-03-13: Henry Winterbottom -- Initial implementation.
+
+"""
+
+# ----
+
+# pylint: disable=fixme
+
+# ----
+
+import functools
+from collections import OrderedDict
+from types import SimpleNamespace
+from typing import Callable, Dict, List, Tuple
+
+import numpy
+from tools import parser_interface
+from utils.logger_interface import Logger
+from xarray import DataArray, merge
+
+# ----
+
+# Define all available module properties
+__all__ = ["ncwrite"]
+
+# ----
+
+logger = Logger(caller_name=__name__)
+
+# ----
+
+
+def __getcoords__(ncio_obj: SimpleNamespace) -> Dict:
+    """
+    Description
+    -----------
+
+    This function defines the Climate and Forecast (CF) Metadata
+    Convention compliant grid-coordinates.
+
+    Parameters
+    ----------
+
+    ncio_obj: ``SimpleNamespace``
+
+        A Python SimpleNamespace object containing the
+        netCDF-formatted output file attributes.
+
+    Returns
+    -------
+
+    coords_dict: ``Dict``
+
+        A Python dictionary containing the CF-compliant grid
+        coordinate attributes.
+
+    """
+
+    # TODO: This function lacks a means to handle unstructured-type
+    # grids; this includes tripolar projections.
+
+    # Build the Python dictionary containing the CF-compliant grid
+    # coordinate attributes.
+    coords_dict = OrderedDict()
+    grid_coords = ncio_obj.grid_coords
+    for var in vars(ncio_obj):
+        varinfo = parser_interface.object_getattr(object_in=ncio_obj, key=var)
+        try:
+            grid_coord_idx = varinfo.grid_coord_idx
+            if grid_coord_idx is not None:
+                values = numpy.array(varinfo.values)
+                if not varinfo.unstructured:
+                    if grid_coord_idx == 1:
+                        values = values[:, 0]
+                    if grid_coord_idx == 2:
+                        values = values[0, :]
+                coords_dict[f"{grid_coords[grid_coord_idx]}"] = values
+        except AttributeError:
+            pass
+
+    return coords_dict
+
+
+# ----
+
+
+def __getvarobj__(ncio_obj: SimpleNamespace) -> SimpleNamespace:
+    """
+    Description
+    -----------
+
+    This function builds a Python SimpleNamespace object containing
+    the output variable attributes.
+
+    Parameters
+    ----------
+
+    ncio_obj: ``SimpleNamespace``
+
+        A Python SimpleNamespace object containing the
+        netCDF-formatted output file attributes.
+
+    Returns
+    -------
+
+    varobj: ``SimpleNamespace``
+
+        A Python SimpleNamespace object containing the output
+        variable attributes.
+
+    """
+
+    # Build the Python SimpleNamespace object containing the output
+    # variable attributes.
+    varobj = parser_interface.object_define()
+    varlist = parser_interface.object_getattr(
+        object_in=ncio_obj, key="ncvarlist", force=True
+    )
+    if varlist is None:
+        msg = "No variables have been defined for output; no output will be written."
+        logger.warn(msg=msg)
+        varobj = None
+    else:
+        for var in varlist:
+            varinfo = parser_interface.object_getattr(
+                object_in=ncio_obj, key=var, force=True
+            )
+            varobj = parser_interface.object_setattr(
+                object_in=varobj, key=var, value=varinfo
+            )
+
+    return varobj
+
+
+# ----
+
+
+def __write__(xarrlist: List[DataArray], ncoutput: str) -> None:
+    """
+    Description
+    -----------
+
+    This function writes the netCDF-formatted file path.
+
+    Parameters
+    ----------
+
+    xarrlist: ``List[DataArray]``
+
+        A Python list of DataArray objects from which to build the
+        netCDF-formatted file path.
+
+    ncoutput: ``str``
+
+        A Python string specifying the netCDF-formatted file path to
+        be written.
+
+    """
+
+    # Build and write the netCDF-formatted file path.
+    dsout = merge(xarrlist)
+    dsout.to_netcdf(ncoutput)
+
+
+# ----
+
+
+def __xarraylist__(varobj: SimpleNamespace, coords_dict: Dict) -> List[DataArray]:
+    """
+    Description
+    -----------
+
+    This method builds a Python list of DataArray objects to be used
+    to build and write the netCDF-formatted file path.
+
+    Parameters
+    ----------
+
+    varobj: ``SimpleNamespace``
+
+        A Python SimpleNamespace object containing the output
+        variable attributes.
+
+    coords_dict: ``Dict``
+
+        A Python dictionary containing the coordinate axis/axes
+        attributees.
+
+    Returns
+    -------
+
+    xarrlist: ``List[DataArray]``
+
+        A Python list of DataArray objects from which to build the
+        netCDF-formatted file path.
+
+    """
+
+    # Build the respective output variable DataArray objects.
+    xarrdslist = []
+    varlist = list(vars(varobj).keys())
+    for var in varlist:
+        varinfo = parser_interface.object_getattr(object_in=varobj, key=var)
+        coords = OrderedDict({key: coords_dict[key] for key in varinfo.coords})
+        msg = f"Building DataArray object for variable {var}."
+        logger.info(msg=msg)
+        xarrdsobj = DataArray(
+            name=var,
+            dims=varinfo.coords,
+            coords=coords,
+            data=numpy.array(varinfo.values),
+        )
+        attributes = parser_interface.object_getattr(
+            object_in=varinfo, key="attributes", force=True)
+        if attributes is not None:
+            xarrdsobj.assign_attrs(attributes) # TODO: Why is this not working?
+        xarrdslist.append(xarrdsobj.to_dataset(name=var))
+
+    return xarrdslist
+
+
+# ----
+
+
+def ncwrite(func: Callable) -> Callable:
+    """
+    Description
+    -----------
+
+    This function is a wrapper function for build and writing
+    netCDF-formatted files.
+
+    Parameters
+    ----------
+
+    func: ``Callable``
+
+        A Python Callable object containing the function to be
+        wrapped.
+
+    Returns
+    -------
+
+    wrapped_function: ``Callable``
+
+        A Python Callable object containing the wrapped function.
+
+    """
+
+    @functools.wraps(func)
+    async def wrapped_function(*args: Tuple, **kwargs: Dict) -> Callable:
+        """
+        Description
+        -----------
+
+        This method builds and writes a specified netCDF-formatted
+        file path.
+
+        Other Parameters
+        ----------------
+
+        args: ``Tuple``
+
+            A Python tuple containing additional arguments passed to
+            the constructor.
+
+        kwargs: ``Dict``
+
+            A Python dictionary containing additional key and value
+            pairs to be passed to the constructor.
+
+        """
+
+        # Build and write the netCDF-formatted file path.
+        ncio_obj = await func(*args, **kwargs)
+        if ncio_obj is not None:
+            coords_dict = __getcoords__(ncio_obj=ncio_obj)
+            varobj = __getvarobj__(ncio_obj=ncio_obj)
+            xarrlist = __xarraylist__(varobj=varobj, coords_dict=coords_dict)
+            __write__(xarrlist=xarrlist, ncoutput=ncio_obj.ncoutput)
+        else:
+            msg = (
+                "No outputs have been specified; a netCDF-formatted file "
+                "will not be written."
+            )
+            logger.warn(msg=msg)
+
+    return wrapped_function

--- a/sorc/tcdiags/io/ncwrite.py
+++ b/sorc/tcdiags/io/ncwrite.py
@@ -258,16 +258,17 @@ def __xarraylist__(varobj: SimpleNamespace, coords_dict: Dict) -> List[DataArray
         coords = OrderedDict({key: coords_dict[key] for key in varinfo.coords})
         msg = f"Building DataArray object for variable {var}."
         logger.info(msg=msg)
+        attributes = parser_interface.object_getattr(
+            object_in=varinfo, key="attributes", force=True
+        )
+        if attributes is None:
+            attributes = {}
         xarrdsobj = DataArray(
             name=var,
             dims=varinfo.coords,
             coords=coords,
             data=numpy.array(varinfo.values),
-        )
-        attributes = parser_interface.object_getattr(
-            object_in=varinfo, key="attributes", force=True)
-        if attributes is not None:
-            xarrdsobj.assign_attrs(attributes) # TODO: Why is this not working?
+        ).assign_attrs(attributes)
         xarrdslist.append(xarrdsobj.to_dataset(name=var))
 
     return xarrdslist

--- a/sorc/tcdiags/io/vario.py
+++ b/sorc/tcdiags/io/vario.py
@@ -60,8 +60,6 @@ History
 
 # ----
 
-from pint import UnitRegistry
-
 from types import SimpleNamespace
 from typing import Tuple, Union
 
@@ -225,7 +223,7 @@ def update_grid(
         )
         logger.warn(msg=msg)
         (xlon_out, xlat_out) = numpy.meshgrid(xlon_in.magnitude,
-                                              xlat_in.magnitude)*UnitRegistry().degrees
+                                              xlat_in.magnitude)*units.degrees
     else:
         msg = (
             "The geographical coordinate arrays are projected to "

--- a/sorc/tcdiags/io/vario.py
+++ b/sorc/tcdiags/io/vario.py
@@ -60,6 +60,8 @@ History
 
 # ----
 
+from pint import UnitRegistry
+
 from types import SimpleNamespace
 from typing import Tuple, Union
 
@@ -222,8 +224,8 @@ def update_grid(
             "are 1-dimensional; converting to gridded values."
         )
         logger.warn(msg=msg)
-
-        (xlon_out, xlat_out) = numpy.meshgrid(xlon_in, xlat_in)
+        (xlon_out, xlat_out) = numpy.meshgrid(xlon_in.magnitude,
+                                              xlat_in.magnitude)*UnitRegistry().degrees
     else:
         msg = (
             "The geographical coordinate arrays are projected to "

--- a/sorc/tcdiags/lv1972_ohc.py
+++ b/sorc/tcdiags/lv1972_ohc.py
@@ -54,6 +54,7 @@ History
 
 import asyncio
 from types import SimpleNamespace
+from typing import Dict, Tuple
 
 import numpy
 from diags.derived.ocean.depths import isodepth
@@ -91,6 +92,19 @@ class LV1972(Diagnostics):
         (supported) applications (see base-class attribute
         `apps_list`).
 
+    Other Parameters
+    ----------------
+
+    args: ``Tuple``
+
+        A Python tuple containing additional arguments passed to the
+        constructor.
+
+    kwargs: ``Dict``
+
+        A Python dictionary containing additional key and value pairs
+        to be passed to the constructor.
+
     References
     ----------
 
@@ -101,7 +115,9 @@ class LV1972(Diagnostics):
 
     """
 
-    def __init__(self: Diagnostics, tcdiags_obj: SimpleNamespace):
+    def __init__(
+        self: Diagnostics, tcdiags_obj: SimpleNamespace, *args: Tuple, **kwargs: Dict
+    ):
         """
         Description
         -----------
@@ -378,7 +394,7 @@ class LV1972(Diagnostics):
 
         return tchp
 
-    def run(self: Diagnostics, *args, **kwargs) -> SimpleNamespace:
+    def run(self: Diagnostics) -> SimpleNamespace:
         """
         Description
         -----------
@@ -387,8 +403,8 @@ class LV1972(Diagnostics):
 
         (1) Computes the TCHP.
 
-        (2) Writes the specified output variables to the specified
-            netCDF-formatted file path.
+        (2) Optionally writes the specified output variables to the
+            specified netCDF-formatted file path.
 
         """
 
@@ -397,6 +413,7 @@ class LV1972(Diagnostics):
         tchp_obj = asyncio.run(self.initialize())
         tchp_obj = asyncio.run(self.setup(tchp_obj=tchp_obj))
         tchp_obj = asyncio.run(self.compute(tchp_obj=tchp_obj))
-        asyncio.run(self.output(varobj=tchp_obj))
+        if self.tcdiags_obj.tcohc.write_output:
+            asyncio.run(self.output(varobj=tchp_obj))
 
         return tchp_obj

--- a/sorc/tcdiags/lv1972_ohc.py
+++ b/sorc/tcdiags/lv1972_ohc.py
@@ -71,6 +71,11 @@ from tcdiags.io.ncwrite import ncwrite
 
 # ----
 
+# Define all available module properties.
+__all__ = ["LV1972"]
+
+# ----
+
 
 class LV1972(Diagnostics):
     """

--- a/sorc/tcdiags/lv1972_ohc.py
+++ b/sorc/tcdiags/lv1972_ohc.py
@@ -255,14 +255,21 @@ class LV1972(Diagnostics):
                     no_split=True,
                 )
             )
+            if (
+                parser_interface.object_getattr(
+                    object_in=ncvar, key="attributes", force=True
+                )
+                is None
+            ):
+                ncvar.attributes = {}
             ncvar.values = parser_interface.object_getattr(object_in=varobj, key=var)
+            ncvar.attributes["units"] = f"{ncvar.values.units}"
             ncout_obj = parser_interface.object_setattr(
                 object_in=ncout_obj, key=var, value=ncvar
             )
         ncout_obj.grid_coords = ["level", "lat", "lon"]
         ncout_obj.ncoutput = self.tcdiags_obj.tcohc.output_file
 
-        # TODO: If ncvarlist is NoneType, do nothing.
         return ncout_obj
 
     async def setup(self: Diagnostics, tchp_obj: SimpleNamespace) -> SimpleNamespace:

--- a/sorc/tcdiags/lv1972_ohc.py
+++ b/sorc/tcdiags/lv1972_ohc.py
@@ -1,0 +1,392 @@
+"""
+Module
+------
+
+    lv1972_ohc.py
+
+Description
+-----------
+
+    This module contains the base-class object for tropical cyclone
+    heat potential (TCHP) computation following the application
+    described in Liepper and Volgenau [1972].
+
+Classes
+-------
+
+    LV1972(tcdiags_obj)
+
+        This is the base-class object for all tropical cyclone (TC)
+        heat-potential computations following Liepper and Volgenau
+        [1972]; it is a sub-class of ``Diagnostics``.
+
+Requirements
+------------
+
+- ufs_pyutils; https://github.com/HenryWinterbottom-NOAA/ufs_pyutils
+
+References
+----------
+
+    Leipper, D. F., and D. Volgenau. "Hurricane heat potential of the
+    Gulf of Mexico". J. Phys. Oceanpgr. 2, 218–224.
+
+Author(s)
+---------
+
+    Henry R. Winterbottom; 07 December 2023
+
+History
+-------
+
+    2023-12-07: Henry Winterbottom -- Initial implementation.
+
+"""
+
+# ----
+
+# pylint: disable=fixme
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
+# pylint: disable=unused-argument
+
+# ----
+
+import asyncio
+from types import SimpleNamespace
+
+import numpy
+from diags.derived.ocean.depths import isodepth
+from diags.derived.ocean.heatcontent import total_heat_content
+from diags.derived.ocean.salinity import absolute_from_practical
+from diags.derived.ocean.temperatures import conservative_from_potential
+from metpy.units import units
+from scipy.interpolate import interp1d
+from tools import parser_interface
+from utils.decorator_interface import privatemethod
+
+from tcdiags.diagnostics import Diagnostics
+from tcdiags.io.ncwrite import ncwrite
+
+# ----
+
+
+class LV1972(Diagnostics):
+    """
+    Description
+    -----------
+
+    This is the base-class object for all tropical cyclone (TC)
+    heat-potential computations following Liepper and Volgenau [1972];
+    it is a sub-class of ``Diagnostics``.
+
+    Parameters
+    ----------
+
+    tcdiags_obj: ``SimpleNamespace``
+
+        A Python SimpleNamespace object containing all configuration
+        attributes for the respective application including inputs
+        (i.e., `inputs` and `tcinfo`) as well as the remaining
+        (supported) applications (see base-class attribute
+        `apps_list`).
+
+    References
+    ----------
+
+    Leipper, D. F., and D. Volgenau. "Hurricane heat potential of the
+    Gulf of Mexico". J. Phys. Oceanpgr. 2, 218–224.
+
+    DOI: https://doi.org/10.1175/1520-0485(1972)002<0218:HHPOTG>2.0.CO;2
+
+    """
+
+    def __init__(self: Diagnostics, tcdiags_obj: SimpleNamespace):
+        """
+        Description
+        -----------
+
+        Creates a new LV1972 object.
+
+        """
+
+        # Define the base-class attributes.
+        super().__init__(tcdiags_obj=tcdiags_obj, app="tcohc")
+
+    @privatemethod
+    async def compute(self: Diagnostics, tchp_obj: SimpleNamespace) -> SimpleNamespace:
+        """
+        Description
+        -----------
+
+        This method computes the gridded tropical cyclone heat
+        potential relative to the specified isotherm depth and the
+        ocean heat content.
+
+        Parameters
+        ----------
+
+        tchp_obj: ``SimpleNamespace``
+
+            A Python SimpleNamespace object containing the attributes
+            required of the TCHP computation.
+
+        Returns
+        -------
+
+        tchp_obj: ``SimpleNamespace``
+
+            A Python SimpleNamespace object containing the TCHP and
+            isotherm depth array values.
+
+        """
+
+        # Compute the depth of the specified isotherm.
+        (tchp_obj.isotherm, _) = await isodepth(
+            varobj=self.tcdiags_obj.inputs,
+            varin=tchp_obj.ctemp.magnitude,
+            isolev=self.tcdiags_obj.tcohc.isotherm,
+        )
+        tchp_obj.isotherm = units.Quantity(tchp_obj.isotherm, "m")
+        isotherm = numpy.array(tchp_obj.isotherm).ravel()
+        depths = numpy.reshape(
+            numpy.array(tchp_obj.depths), (tchp_obj.nz, tchp_obj.nx * tchp_obj.ny)
+        )
+        ohc = numpy.reshape(
+            numpy.array(tchp_obj.ohc), (tchp_obj.nz, tchp_obj.nx * tchp_obj.ny)
+        )
+
+        # Compute the TCHP.
+        tchp = numpy.empty(numpy.shape(isotherm))
+        msg = (
+            "Computing the tropical cyclone heat potential relative to the "
+            f"{self.tcdiags_obj.tcohc.isotherm}C isotherm."
+        )
+        self.logger.info(msg=msg)
+        tchp = [
+            await self.tchp(
+                ohc[:, idx],
+                isotherm[idx],
+                depths[:, idx],
+                interp_type=self.tcdiags_obj.tcohc.interp_type,
+                fill_value=self.tcdiags_obj.tcohc.fill_value,
+                deltaz=self.tcdiags_obj.tcohc.deltaz,
+            )
+            for idx in range(tchp_obj.nx * tchp_obj.ny)
+        ]
+        tchp_obj.tchp = units.Quantity(
+            numpy.reshape(tchp, numpy.shape(tchp_obj.isotherm)), tchp_obj.ohc.units
+        )
+
+        return tchp_obj
+
+    @privatemethod
+    async def initialize(self: Diagnostics) -> SimpleNamespace:
+        """
+        Description
+        -----------
+
+        This method initialized the Python SimpleNamespace object
+        containing the attributes required to compute the TCHP.
+
+        Returns
+        -------
+
+        tchp_obj: ``SimpleNamespace``
+
+            A Python SimpleNamespace object containing the attributes
+            required of the TCHP computation.
+
+        """
+
+        # Initialize the TCHP computation.
+        tchp_obj = parser_interface.object_define()
+        tchp_obj.lats = units.Quantity(
+            self.tcdiags_obj.inputs.latitude.values, "degree"
+        )
+        tchp_obj.lons = units.Quantity(
+            self.tcdiags_obj.inputs.longitude.values, "degree"
+        )
+        tchp_obj.depths = units.Quantity(self.tcdiags_obj.inputs.depth.values, "m")
+        tchp_obj.ohc = await total_heat_content(varobj=self.tcdiags_obj.inputs)
+        tchp_obj.ctemp = units.Quantity(
+            await conservative_from_potential(varobj=self.tcdiags_obj.inputs), "degC"
+        )
+        tchp_obj.asaln = units.Quantity(
+            await absolute_from_practical(varobj=self.tcdiags_obj.inputs), "g/kg"
+        )
+
+        return tchp_obj
+
+    @ncwrite
+    async def output(self: Diagnostics, varobj: SimpleNamespace) -> SimpleNamespace:
+        """
+        Description
+        -----------
+
+        This method defines the attributes for the netCDF-formatted
+        output file and subsequently writes the specified
+        netCDF-formatted output file path.
+
+        Parameters
+        ----------
+
+        varobj: ``SimpleNamespace``
+
+            A Python SimpleNamespace object containing the
+            netCDF-formatted output file attributes and the respective
+            output variable attributes.
+
+        """
+
+        # Define the netCDF-formatted output file attributes and write
+        # the netCDF-formatted file path.
+        ncout_obj = parser_interface.object_deepcopy(object_in=self.tcdiags_obj.inputs)
+        ncout_obj.ncvarlist = list(self.tcdiags_obj.tcohc.output_vars.keys())
+        for var in ncout_obj.ncvarlist:
+            ncvar = parser_interface.dict_toobject(
+                in_dict=parser_interface.dict_key_value(
+                    dict_in=self.tcdiags_obj.tcohc.output_vars,
+                    key=var,
+                    force=True,
+                    no_split=True,
+                )
+            )
+            ncvar.values = parser_interface.object_getattr(object_in=varobj, key=var)
+            ncout_obj = parser_interface.object_setattr(
+                object_in=ncout_obj, key=var, value=ncvar
+            )
+        ncout_obj.grid_coords = ["level", "lat", "lon"]
+        ncout_obj.ncoutput = self.tcdiags_obj.tcohc.output_file
+
+        # TODO: If ncvarlist is NoneType, do nothing.
+        return ncout_obj
+
+    async def setup(self: Diagnostics, tchp_obj: SimpleNamespace) -> SimpleNamespace:
+        """
+        Description
+        -----------
+
+        This method defines the netCDF-formatted output file
+        attributes.
+
+        Parameters
+        ----------
+
+        tchp_obj: ``SimpleNamespace``
+
+            A Python SimpleNamespace object containing the attributes
+            required of the TCHP computation.
+
+        Returns
+        -------
+
+        tchp_obj: ``SimpleNamespace``
+
+            A Python SimpleNamespace object containing the
+            netCDF-formatted output file attributes.
+
+        """
+
+        # Define the netCDF-formatted output file attributes.
+        tchp_obj.ncoutput = self.tcdiags_obj.tcohc.output_file
+        (tchp_obj.nz, tchp_obj.ny, tchp_obj.nx) = numpy.shape(
+            numpy.array(tchp_obj.depths)
+        )
+        tchp_obj.coords_dict = {}
+        tchp_obj.coords_dict["level"] = {
+            "coord": "z",
+            "values": numpy.linspace(
+                0, len(numpy.array(self.tcdiags_obj.inputs.depth_profile.values)), 1
+            ),
+        }
+        tchp_obj.coords_dict["lat"] = {
+            "coord": "y",
+            "values": numpy.array(tchp_obj.lats),
+        }
+        tchp_obj.coords_dict["lon"] = {
+            "coord": "x",
+            "values": numpy.array(tchp_obj.lons),
+        }
+
+        return tchp_obj
+
+    @staticmethod
+    async def tchp(ohc, isodepth, depths, interp_type, fill_value, deltaz) -> float:
+        """
+        Description
+        -----------
+
+        This method computes the tropical cyclone heat potential
+        (TCHP) assuming the algorithm described by Liepper and
+        Volgenau [1972].
+
+        Parameters
+        ----------
+
+        ohc: ``numpy.array``
+
+            A 2-dimensional variable array, ordered as (nz, nx*ny),
+            containing the ocean heat content.
+
+        isodepth: ``float``
+
+            A Python float value defining the depth of the isothermal
+            level from which to compute the TCHP.
+
+        depths: ``numpy.array``
+
+            A Python 1-dimensional variable array containing the
+            vertical levels, increasing with depth.
+
+        Returns
+        -------
+
+        tchp: ``float``
+
+            A Python float value containing the integrated TCHP.
+
+        """
+
+        # TODO: Add a minimal depth for which to compute TCHP; i.e.,
+        # if anything shallower than `N`, do not compute.
+
+        # Compute the integrated ocean heat content relative to the
+        # respective isotherm depth.
+        tchp = 0.0
+        if isodepth <= numpy.max(depths):
+            ohcintrp = interp1d(
+                ohc[:], depths[:], kind=interp_type, fill_value=fill_value
+            )
+            depth = numpy.min(depths[:])
+            while depth <= isodepth:
+                try:
+                    tchp = tchp + ohcintrp(depth)
+                except ValueError:
+                    break
+                depth = depth + deltaz
+
+        return tchp
+
+    def run(self: Diagnostics, *args, **kwargs) -> SimpleNamespace:
+        """
+        Description
+        -----------
+
+        This method performs the following tasks:
+
+        (1) Computes the TCHP.
+
+        (2) Writes the specified output variables to the specified
+            netCDF-formatted file path.
+
+        """
+
+        # Compute the TCHP and write the specified netCDF-formatted
+        # file path.
+        tchp_obj = asyncio.run(self.initialize())
+        tchp_obj = asyncio.run(self.setup(tchp_obj=tchp_obj))
+        tchp_obj = asyncio.run(self.compute(tchp_obj=tchp_obj))
+        asyncio.run(self.output(varobj=tchp_obj))
+
+        return tchp_obj

--- a/sorc/tcdiags/lv1972_ohc.py
+++ b/sorc/tcdiags/lv1972_ohc.py
@@ -147,6 +147,9 @@ class LV1972(Diagnostics):
             varin=tchp_obj.ctemp.magnitude,
             isolev=self.tcdiags_obj.tcohc.isotherm,
         )
+        tchp_obj.isotherm = numpy.ma.where(
+            tchp_obj.isotherm <= numpy.nanmax(tchp_obj.isotherm), tchp_obj.isotherm, 0.0
+        )
         tchp_obj.isotherm = units.Quantity(tchp_obj.isotherm, "m")
         isotherm = numpy.array(tchp_obj.isotherm).ravel()
         depths = numpy.reshape(

--- a/sorc/tcdiags/tcdiags.py
+++ b/sorc/tcdiags/tcdiags.py
@@ -93,7 +93,9 @@ class TCDiags:
         self.yaml_obj = YAML().read_yaml(yaml_file=self.yaml_file, return_obj=True)
 
         # Define the available applications.
-        self.apps_list = ["tcmsi", "tcpi", "tcstrflw"]
+        
+        # TODO: Move this to a schema interface.
+        self.apps_list = ["tcmsi", "tcohc", "tcpi", "tcstrflw"]
 
     def config(self: Generic) -> SimpleNamespace:
         """


### PR DESCRIPTION
## Pull Request

**Description**

This PR addresses issue #56. The following is accomplished:

- Support is added to compute the ocean heat content (OHC) using the [GSW](https://www.teos-10.org/pubs/gsw/html/gsw_contents.html) package;
- Support is added to compute the tropical cyclone heat potential (TCHP) in accordance with [Leipper and Volgenau (1972)](https://journals.ametsoc.org/view/journals/phoc/2/3/1520-0485_1972_002_0218_hhpotg_2_0_co_2.xml);
- New configuration files are added for the ocean applications and the TCHP diagnostics;
- A new wrapper function has been introduced for netCDF-formatted output file creation; this will be introduced to the remaining methods in subsequent PRs;
- The Sphinx documentation has been updated relative to the above additions; placeholders remain to be addressed in subsequent PRs.

**Related Issues**

- Closes #56 

# Checklist

- [x] Any dependent changes have been merged and published.
- [x] Any new coding follows the style guidelines of this project and have been commented and reviewed prior to pull-request.
- [x] New coding does not cause new warnings.
- [x] All current unit-tests pass with new changes.
- [x] Any new documentation required of the pull-request have been included.